### PR TITLE
remove the skipTests configuration from openshift profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,13 +167,6 @@
               </generator>
             </configuration>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
       <dependencies>


### PR DESCRIPTION
This is inconsistent with other Swarm boosters, and there's
really no need to skip tests in the openshift profile
by default. It might possibly speedup deployment a bit,
which is probably why the Jenkinsfile uses -DskipTests,
but that's no reason to skip tests by default in the POM.