### PR TITLE
[ENTSWM-201] don't use @CreateSwarm

### DIFF
--- a/pom-redhat.xml
+++ b/pom-redhat.xml
@@ -194,6 +194,19 @@
           <version>${version.h2}</version>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <swarm.project.stage>local</swarm.project.stage>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/pom-redhat.xml
+++ b/pom-redhat.xml
@@ -264,6 +264,13 @@
       <id>openshift-it</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
           <!--
             - 1.
             -

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,19 @@
           <version>${version.h2}</version>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <swarm.project.stage>local</swarm.project.stage>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,13 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
               <execution>

--- a/src/test/java/io/openshift/boosters/FruitServiceTest.java
+++ b/src/test/java/io/openshift/boosters/FruitServiceTest.java
@@ -31,8 +31,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
 
 /**
@@ -41,14 +39,6 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
 @RunWith(Arquillian.class)
 @DefaultDeployment
 public class FruitServiceTest {
-
-    /**
-     * For the unit tests we leverage in in-memory database
-     */
-    @CreateSwarm
-    public static Swarm newContainer() throws Exception {
-        return new Swarm().withProfile("local");
-    }
 
     @Test
     @RunAsClient


### PR DESCRIPTION
The `@CreateSwarm` annotation is deprecated and we shouldn't
use it in boosters tests. Fortunately, its usage was limited
to only enabling a correct profile for unit tests, which can
be achieved using a system property.